### PR TITLE
A class to display text only for screen-readers

### DIFF
--- a/styles/abstracts/_helpers.scss
+++ b/styles/abstracts/_helpers.scss
@@ -25,3 +25,15 @@
   display: table;
   clear: both;
 }
+
+// screen-reader only eg. text within links that are images (social-buttons)
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0,0,0,0);
+    border: 0;
+}


### PR DESCRIPTION
sometimes text needs to be hidden for visual users (i.e. when links are styled with background-images).

This class is the best way to do that.

Currently, in toga, there is a style that moves text -9999px which is inefficient and is known to be damaging to performance.  This helper class will ensure people do it in a consistent way in the future.