### PR TITLE
Prefixing all toolkit styles to toga components

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "yargs": "^4.7.1"
   },
   "dependencies": {
-    "express": "^4.13.4"
+    "express": "^4.13.4",
+    "postcss-prefix-selector": "^1.4.0"
   }
 }

--- a/styles/base/_typography.scss
+++ b/styles/base/_typography.scss
@@ -1,7 +1,7 @@
 @import "../abstracts/variables";
 @import "../abstracts/mixins";
 
-body, p, input, textarea, keygen, select, button {
+* {
   font-family: $font;
   font-style: normal;
   color: $font-color;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack');
 const path = require('path');
 const autoprefixer = require('autoprefixer');
+const prefix = require('postcss-prefix-selector')
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 module.exports = {
@@ -42,5 +43,7 @@ module.exports = {
         add: true,
         remove: true
       }
+  ), prefix({
+    prefix: '[toga] '}
   )]
 };


### PR DESCRIPTION
We are _**temporarily**_ prefixing all of the styles to toga components as some of the pages are not following the toolkit and things like [This line](https://github.com/notonthehighstreet/styles-toolkit/blob/master/styles/base/_typography.scss#L4) are breaking some of the pages. 

Talking to Yani we need to give the other teams time to update their pages then we can remove this namespacing.

Also not sure if this is the best way to do it, open to suggestions